### PR TITLE
Rebuild 0.1.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+channels:
+  jcmorin-ana-org: aws
+
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,0 @@
-channels:
-  jcmorin-ana-org: aws
-
-build_parameters:
-  - "--suppress-variables"
-  #- "--skip-existing"
-  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9312e305428655bcea1f81524c3a8f617ce5299b903187047078929e850fb6d4
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage("aws-checksums", max_pin="x.x.x") }}
 
@@ -20,7 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - ninja
   host:
-    - aws-c-common
+    - aws-c-common 0.6.8
 
 test:
   commands:
@@ -33,7 +33,12 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: Cross-Platform HW accelerated CRC32c and CRC32 with fallback to efficient SW implementations. C interface with language bindings for each of our SDKs.
+  description: Cross-Platform HW accelerated CRC32c and CRC32 with fallback to efficient SW implementations. C interface with language bindings for each of our SDKs.
+  dev_url: https://github.com/awslabs/aws-checksums
+  doc_url: https://github.com/awslabs/aws-checksums
 
 extra:
+  skip-lints:
+    - missing_tests
   recipe-maintainers:
     - xhochy


### PR DESCRIPTION
Rebuild to get consistent dependencies across platforms.

For example, the linux-64 build was depending on `aws-c-common >=0.4.65,<0.4.66.0a0` while on osx-arm64 it was depending on `aws-c-common >=0.6.8,<0.6.9.0a0`.

This is creating conflicts when trying to rebuild `aws-c-event-stream` an `aws-sdk-cpp`.

Depends on:
* https://github.com/AnacondaRecipes/aws-c-common-feedstock/pull/16