### PR TITLE
update to 0.1.13

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/aws-c-common-feedstock/pr17/fdb0797

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/aws-c-common-feedstock/pr17/fdb0797

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   build:
     - cmake !=3.19.0,!=3.19.1
     - {{ compiler('c') }}
-    - ninja
+    - ninja-base
   host:
     - aws-c-common 0.8.5
 
@@ -26,6 +26,8 @@ test:
   commands:
     - test -f $PREFIX/lib/libaws-checksums${SHLIB_EXT}  # [unix]
     - test -f $PREFIX/include/aws/checksums/exports.h  # [unix]
+    - if not exist %PREFIX%\\Library\\bin\\aws-checksums.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\include\\aws\\checksums\\exports.h exit 1  # [win]
 
 about:
   home: https://github.com/awslabs/aws-checksums

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-checksums" %}
-{% set version = "0.1.11" %}
+{% set version = "0.1.13" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 9312e305428655bcea1f81524c3a8f617ce5299b903187047078929e850fb6d4
+  sha256: 0f897686f1963253c5069a0e495b85c31635ba146cd3ac38cc2ea31eaf54694d
 
 build:
-  number: 2
+  number: 0
   run_exports:
     - {{ pin_subpackage("aws-checksums", max_pin="x.x.x") }}
 
@@ -20,7 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - ninja
   host:
-    - aws-c-common 0.6.8
+    - aws-c-common 0.8.5
 
 test:
   commands:


### PR DESCRIPTION
aws-checksum 0.1.13

**Destination channel:** defaults

### Links

- [{ticket_number}](https://anaconda.atlassian.net/browse/PKG-3914) 
- [Upstream repository](https://github.com/awslabs/aws-checksums/releases/tag/v0.1.13)

dependency for aws-sdk-cpp 1.10.55 -> arrow-cpp 14.0.1 -> pyarrow 14.0.1 which would address CVE