### PR TITLE
aws-checksums 0.2.3 rebuild

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,14 +1,20 @@
 mkdir "%SRC_DIR%"\build
 pushd "%SRC_DIR%"\build
 
-cmake -G "Ninja" ^
+cmake -GNinja ^
       -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
       -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
       -DCMAKE_INSTALL_LIBDIR=lib ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DBUILD_SHARED_LIBS=ON ^
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON ^
+      -DENABLE_TESTING=ON ^
+
       ..
 if errorlevel 1 exit 1
 
-ninja install
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+ctest --output-on-failure
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,6 +10,11 @@ cmake ${CMAKE_ARGS} -GNinja \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=ON \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DENABLE_TESTING=ON \
   ..
-ninja install
+
+cmake --build . --config Release --target install
+
+ctest --output-on-failure -j${CPU_COUNT}
 popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c688f311db8a1b70bb6d22f6e8f2817b39e1419546e339cf753d61340969eeb4
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-checksums", max_pin="x.x.x") }}
 
@@ -20,7 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - ninja-base
   host:
-    - aws-c-common 0.11.1
+    - aws-c-common 0.12.3
 
 test:
   commands:


### PR DESCRIPTION
aws-checksums 0.2.3 rebuild

**Destination channel:** Defaults

### Links

- [PKG-8588]
- dev_url:        https://github.com/awslabs/aws-c-io/tree/v0.20.1
- conda_forge:    https://github.com/conda-forge/aws-checksums-feedstock
- pypi:           https://pypi.org/project/aws-checksums/0.2.3
- pypi inspector: https://inspector.pypi.io/project/aws-checksums/0.2.3/

### Explanation of changes:

- rebuild due to new dependency versions


[PKG-8588]: https://anaconda.atlassian.net/browse/PKG-8588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ