### PR TITLE
aws-checksums 0.2.10 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: cb6509f75e42ee25c372a6d379e8582ce5179e5335183842e808f7d8abb0c314
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-checksums", max_pin="x.x.x") }}
 
@@ -21,7 +21,7 @@ requirements:
     - cmake >=3.9
     - ninja-base
   host:
-    - aws-c-common 0.12.6
+    - aws-c-common 0.14.0
 
 test:
   commands:


### PR DESCRIPTION
aws-checksums 0.2.10 

**Destination channel:** Defaults

### Links

- [PKG-15443]
- dev_url:        https://github.com/awslabs/aws-checksums/tree/v0.2.10
- conda_forge:    https://github.com/conda-forge/aws-checksums-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- new aws-c-common version number


[PKG-15443]: https://anaconda.atlassian.net/browse/PKG-15443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ